### PR TITLE
[change] webhook_controller.rb & [add] .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+# 環境変数
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,6 @@ gem 'sinatra'
 gem 'bootsnap', require: false
 
 gem 'listen', group: :development
+
+# 環境変数ようのgemを作成
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,7 +26,7 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: event.message['text']
+            text: "userId: " + event['source']['userId'] + "\n" + "groupId: " + event['source']['groupId']
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << /[a-z0-9]+\.ngrok\.io/
+  config.hosts << '.ngrok.io'
 end


### PR DESCRIPTION
## 実装の背景・目的

特定のグループにメッセージを送信するため，userIdとgroupIdの取得を行なった．
また，ローカル環境で実行するために.envを用意し，トークンとシークレットを代入した．

## やったこと

- メッセージを送信元のuserIdとgroupIdに変更．
- .envを作成し，トークンとシークレットを代入
- .envは.gitignoreに記入済み

## キャプチャ


## 補足

- 今回はグループでメッセージを送信すると．送信者とそのグループIDが返信されます．
- 次は，グループIDをハードコーディングして，個人トークからグループトークにメッセージが送信されるようにします． 
