### PR TITLE
個人チャットのメッセージを特定のグループチャットに送信

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -28,7 +28,7 @@ class WebhookController < ApplicationController
             type: 'text',
             text: event.message['text']
           }
-          client.push_message("C4dadc5fd1b923ccd5b9ef364aa5155da", message)
+          client.push_message(ENV['GROUP_ID'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -28,7 +28,7 @@ class WebhookController < ApplicationController
             type: 'text',
             text: event.message['text']
           }
-          client.reply_message("C4dadc5fd1b923ccd5b9ef364aa5155da", message)
+          client.push_message("C4dadc5fd1b923ccd5b9ef364aa5155da", message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,9 +26,9 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: "userId: " + event['source']['userId'] + "\n" + "groupId: " + event['source']['groupId']
+            text: event.message['text']
           }
-          client.reply_message(event['replyToken'], message)
+          client.reply_message("C4dadc5fd1b923ccd5b9ef364aa5155da", message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << '.ngrok.io'
+  config.hosts << /[a-zA-Z0-9]+\.ngrok\.io/
 end


### PR DESCRIPTION
## 実装の背景・目的

今回の実装で個人の発言をBOTが代わりに発言してくれるようになりました！
BOTがグループにいれば，遊びやご飯に誘いやすくなります．

## やったこと

- BOTのメッセージ内容を送信者の発言と同じにしました．
- 送信先をグループIDでハードコーディングしました．

## キャプチャ
![個人チャット](https://user-images.githubusercontent.com/82089820/142605398-cd419140-65c7-4f5a-96e3-6d516f96d7c5.png)


![グループチャット](https://user-images.githubusercontent.com/82089820/142606088-541ffb73-c37a-40fc-99a5-cca14f7e5f22.png)

## 補足

- 次は外部API機能の実装です．
