### PR TITLE
個人チャットの内容をHot PepperAPIを用いて検索し，グループチャットに送信

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,7 +1,4 @@
-require 'json'
 require 'line/bot'
-require 'net/http'
-require 'uri'
 
 require './app/models/create_content'
 require './app/models/food_search_api'
@@ -37,7 +34,7 @@ class WebhookController < ApplicationController
           res_data = FoodSearchAPI.search(place, food)
 
           # お勧め飲食店が3店舗以上ある場合
-          if res_data["results"]["results_returned"].to_i >= 3
+          if res_data["results"]["results_returned"].to_i >= 1
 
             # グループチャットに久々メッセージ送信
             greeting = CreateContent.greeting(place, food)
@@ -45,7 +42,6 @@ class WebhookController < ApplicationController
 
             # グループチャットにお勧め飲食店を送信
             messages = CreateContent.recommend_store(res_data)
-            puts messages
             messages.each do |message|
               client.push_message(ENV['GROUP_ID'], message)
             end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,4 +1,7 @@
+require 'json'
 require 'line/bot'
+require 'net/http'
+require 'uri'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -10,9 +13,24 @@ class WebhookController < ApplicationController
     }
   end
 
+  # 飲食店検索
+  def food_search_api(place, food)
+    data = {
+      "key": "01458b22b6dce274",
+      "address": place,
+      "keyword": food
+    }
+    query = data.to_query
+    uri = URI("http://webservice.recruit.co.jp/hotpepper/gourmet/v1/?" + query)
+    http = Net::HTTP.new(uri.host, uri.port)
+    req = Net::HTTP::Get.new(uri)
+    res = http.request(req)
+    res_data = Hash.from_xml(res.body)
+    return res_data
+  end
+
   def callback
     body = request.body.read
-
     signature = request.env['HTTP_X_LINE_SIGNATURE']
     unless client.validate_signature(body, signature)
       head 470
@@ -24,11 +42,35 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          text = event.message['text'].split("、")
+          place = text[0]
+          food = text[1]
+          res_data = food_search_api(place, food)
+
+          hello_content = <<~EOS
+          久しぶり〜！今度みんなでご飯でもどう？
+          #{place}でお勧めの#{food}を紹介するね！
+          EOS
+
           message = {
             type: 'text',
-            text: event.message['text']
+            text: hello_content
           }
           client.push_message(ENV['GROUP_ID'], message)
+
+          for i in 0..2 do
+            recommend_store = <<~EOS
+            店名： #{res_data['results']['shop'][i]['name']}
+            最寄駅： #{res_data['results']['shop'][i]['station_name']}
+            URL： #{res_data['results']['shop'][i]['urls']['pc']}
+            EOS
+            message = {
+              type: 'text',
+              text: recommend_store
+            }
+            client.push_message(ENV['GROUP_ID'], message)
+          end
+        
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/models/create_content.rb
+++ b/app/models/create_content.rb
@@ -1,0 +1,48 @@
+class CreateContent
+
+    def self.greeting_only
+        # 挨拶メッセージ作成
+        greeting = <<~EOS
+        久しぶり〜！今度みんなでご飯でもどう？
+        EOS
+        message = {
+            type: 'text',
+            text: greeting
+        }
+        return message
+    end
+
+    def self.greeting(place, food)
+        # 挨拶メッセージ作成
+        greeting = <<~EOS
+        久しぶり〜！今度みんなでご飯でもどう？
+        #{place}でお勧めの#{food}を紹介するね！
+        EOS
+        message = {
+            type: 'text',
+            text: greeting
+        }
+        return message
+    end
+
+    def self.recommend_store(res_data)
+        # お勧め飲食店メッセージ作成
+        messages = []
+        shops = res_data['results']['shop']
+        # 表示数を設定
+        limit = 3
+        shops.first(limit).each do |shop|
+            recommend_store = <<~EOS
+            店名： #{shop['name']}
+            最寄駅： #{shop['station_name']}
+            URL： #{shop['urls']['pc']}
+            EOS
+            message = {
+              type: 'text',
+              text: recommend_store
+            }
+            messages.push(message)
+        end
+        return messages
+    end
+end

--- a/app/models/create_content.rb
+++ b/app/models/create_content.rb
@@ -1,4 +1,6 @@
 class CreateContent
+    # 表示数を設定
+    LIMIT = 3
 
     def self.greeting_only
         # 挨拶メッセージ作成
@@ -9,7 +11,6 @@ class CreateContent
             type: 'text',
             text: greeting
         }
-        return message
     end
 
     def self.greeting(place, food)
@@ -22,16 +23,13 @@ class CreateContent
             type: 'text',
             text: greeting
         }
-        return message
     end
 
     def self.recommend_store(res_data)
         # お勧め飲食店メッセージ作成
         messages = []
         shops = res_data['results']['shop']
-        # 表示数を設定
-        limit = 3
-        shops.first(limit).each do |shop|
+        shops.first(LIMIT).each do |shop|
             recommend_store = <<~EOS
             店名： #{shop['name']}
             最寄駅： #{shop['station_name']}
@@ -43,6 +41,6 @@ class CreateContent
             }
             messages.push(message)
         end
-        return messages
+        messages
     end
 end

--- a/app/models/food_search_api.rb
+++ b/app/models/food_search_api.rb
@@ -1,0 +1,18 @@
+class FoodSearchAPI
+
+    def self.search(place, food)
+        data = {
+          "key": ENV['API_KEY'], 
+          "address": place,
+          "keyword": food
+        }
+        query = data.to_query
+        uri = URI("http://webservice.recruit.co.jp/hotpepper/gourmet/v1/?" + query)
+        http = Net::HTTP.new(uri.host, uri.port)
+        req = Net::HTTP::Get.new(uri)
+        res = http.request(req)
+        res_data = Hash.from_xml(res.body)
+        return res_data
+    end
+
+end

--- a/app/models/food_search_api.rb
+++ b/app/models/food_search_api.rb
@@ -1,3 +1,7 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
 class FoodSearchAPI
 
     def self.search(place, food)
@@ -11,8 +15,7 @@ class FoodSearchAPI
         http = Net::HTTP.new(uri.host, uri.port)
         req = Net::HTTP::Get.new(uri)
         res = http.request(req)
-        res_data = Hash.from_xml(res.body)
-        return res_data
+        Hash.from_xml(res.body)
     end
 
 end

--- a/app/models/message_analysis.rb
+++ b/app/models/message_analysis.rb
@@ -1,0 +1,10 @@
+class MessageAnalysis
+
+    def self.analysis(text)
+        # 個人メッセージから場所と料理を返す
+        text = text.gsub(" ", ",").gsub("、", ",").gsub("　", ",")
+        place, food = text.split(",")
+        return place, food
+    end
+
+end

--- a/app/models/message_analysis.rb
+++ b/app/models/message_analysis.rb
@@ -4,7 +4,6 @@ class MessageAnalysis
         # 個人メッセージから場所と料理を返す
         text = text.gsub(" ", ",").gsub("、", ",").gsub("　", ",")
         place, food = text.split(",")
-        return place, food
     end
 
 end


### PR DESCRIPTION
## 実装の背景・目的

個人チャットの内容からHot PepperAPIを用いてお勧めの飲食店を検索し，その結果をグループチャットに送信

## やったこと

- webhook_controller.rbにfood_search_api関数を追加
- webhook_controller.rbのcallback関数の送信内容を変更

## キャプチャ

![個人チャットに場所，料理を送信](https://user-images.githubusercontent.com/82089820/143174764-f404dbd5-1674-43dc-8980-42e000cffa30.png)

![グループチャットにお勧めの飲食店を送信](https://user-images.githubusercontent.com/82089820/143174780-dbca3ded-2a15-4c77-b643-2c4ca4d06a9c.png)

## 補足

- 個人チャットで送信するときは「場所、料理」でなければ，反応がない．( 修正の必要あり)
