### PR TITLE
Groupテーブル，Userテーブル，Group_userテーブルの作成

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,6 @@
+class Group < ApplicationRecord
+  validates :line_group_id, uniqueness: true
+  has_many :group_users
+  has_many :users, through: :group_users
+  accepts_nested_attributes_for :group_users
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  validates :line_user_id, uniqueness: true
+  has_many :group_users
+  has_many :groups, through: :group_users
+end

--- a/db/migrate/20211125020846_create_users.rb
+++ b/db/migrate/20211125020846_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :line_user_id, null: false
+      t.string :display_name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211125021633_create_groups.rb
+++ b/db/migrate/20211125021633_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :groups do |t|
+      t.string :line_group_id, null: false
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211125022041_create_group_users.rb
+++ b/db/migrate/20211125022041_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :group_users do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }
+      t.references :group, null: false, foreign_key: { on_delete: :cascade }
+      t.timestamps
+    end
+    add_index :group_users, [:group_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_112934) do
+ActiveRecord::Schema.define(version: 2021_11_25_022041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "group_users", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id", "user_id"], name: "index_group_users_on_group_id_and_user_id", unique: true
+    t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id"], name: "index_group_users_on_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "line_group_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "line_user_id", null: false
+    t.string "display_name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "widgets", force: :cascade do |t|
     t.string "name"
@@ -23,4 +47,6 @@ ActiveRecord::Schema.define(version: 2020_02_13_112934) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "group_users", "groups", on_delete: :cascade
+  add_foreign_key "group_users", "users", on_delete: :cascade
 end


### PR DESCRIPTION
## 実装の背景・目的

Line_user_idからその人が所属しているLINEグループを取得するため，多対多のテーブルを作成．

## やったこと

- Userテーブルの作成
- Groupテーブルの作成
- Group_Userテーブルの作成

## キャプチャ

## 補足

-  全てのテーブルの全てのカラムをnull false
- Groupテーブルのline_user_id, Userテーブルのline_group_id, Group_userテーブルの(user_id, group_id)はuniqueness

