### PR TITLE
個人チャットからグループを選択

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,10 +1,7 @@
 require 'line/bot'
 
-require './app/models/create_content'
-require './app/models/food_search_api'
-require './app/models/message_analysis'
-
 class WebhookController < ApplicationController
+  STATE = 0
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
   def client
@@ -27,28 +24,44 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          # 個人チャットから「場所，料理」を取得
-          place, food = MessageAnalysis.analysis(event.message['text'])
 
-          # 場所，料理からお勧めの飲食店を検索
-          res_data = FoodSearchAPI.search(place, food)
-
-          # お勧め飲食店が3店舗以上ある場合
-          if res_data["results"]["results_returned"].to_i >= 1
-
-            # グループチャットに久々メッセージ送信
-            greeting = CreateContent.greeting(place, food)
-            client.push_message(ENV['GROUP_ID'], greeting)
-
-            # グループチャットにお勧め飲食店を送信
-            messages = CreateContent.recommend_store(res_data)
-            messages.each do |message|
-              client.push_message(ENV['GROUP_ID'], message)
+          if event.message['text'] == "お久しぶり"
+            group_names = []
+            line_user_id = event['source']['userId']
+            @user = User.find_by(line_user_id: line_user_id)
+            @user.group_users.each do |group_user|
+              group_names.push(group_user.group.name)
             end
-          else
-            # お勧め店舗が2店舗以下の場合，挨拶のみ
-            greeting_only = CreateContent.greeting_only
-            client.push_message(ENV['GROUP_ID'],greeting_only)
+            message = CreateContent.recommend_group(group_names)
+            client.push_message(line_user_id, message)
+            message = CreateContent.sample_message
+            client.push_message(line_user_id, message)
+          end
+
+          if event.message['text'].start_with?("メッセージ")
+            group_name, place, food = MessageAnalysis.analysis(event.message['text'])
+            @group = Group.find_by(name: group_name)
+            line_group_id = @group.line_group_id
+            # 場所，料理からお勧めの飲食店を検索
+            res_data = FoodSearchAPI.search(place, food)
+            # お勧め飲食店が1店舗以上ある場合
+            if res_data["results"]["results_returned"].to_i >= 1
+
+              # グループチャットに久々メッセージ送信
+              greeting = CreateContent.greeting(place, food)
+              client.push_message(line_group_id, greeting)
+
+              # グループチャットにお勧め飲食店を送信
+              messages = CreateContent.recommend_store(res_data)
+              messages.each do |message|
+                client.push_message(line_group_id, message)
+              end
+            else
+              # お勧め店舗が0店舗以下の場合，挨拶のみ
+              greeting_only = CreateContent.greeting_only
+              client.push_message(line_group_id, greeting_only)
+            end
+            
           end
         
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
@@ -56,7 +69,36 @@ class WebhookController < ApplicationController
           tf = Tempfile.open("content")
           tf.write(response.body)
         end
+
+      when Line::Bot::Event::MemberJoined
+        line_group_id = event['source']['groupId']
+        event['joined']['members'].each do |member|
+          line_user_id = member['userId']
+          res = JSON.parse(client.get_group_member_profile(line_group_id, line_user_id).body)
+          display_name = res['displayName']
+          @user = User.find_or_initialize_by(line_user_id: line_user_id, display_name: display_name)
+          if @user.new_record?
+            @user.save
+          end
+          @group = Group.find_by(line_group_id: line_group_id)
+          begin
+            @group.users << @user
+          rescue => e
+            puts e
+          end
+        end
+
+      when Line::Bot::Event::Join
+        line_group_id = event['source']['groupId']
+        group_name = LineAPI.bot_join(line_group_id)
+        @group = Group.new(line_group_id: line_group_id, name: group_name)
+        begin
+          @group.save
+        rescue => e
+          puts e
+        end
       end
+
     }
     head :ok
   end

--- a/app/models/create_content.rb
+++ b/app/models/create_content.rb
@@ -2,10 +2,13 @@ class CreateContent
   # 表示数を設定
     LIMIT = 3
 
+  # グループに送信するメッセージ
+
   def self.greeting_only
     # 挨拶メッセージ作成
     greeting = <<~EOS
-    久しぶり〜！今度みんなでご飯でもどう？
+    久しぶり！
+    今度みんなでご飯でもどう？
     EOS
     message = {
       type: 'text',
@@ -16,7 +19,8 @@ class CreateContent
   def self.greeting(place, food)
     # 挨拶メッセージ作成
     greeting = <<~EOS
-    久しぶり〜！今度みんなでご飯でもどう？
+    久しぶり！
+    今度みんなでご飯でもどう？
     #{place}でお勧めの#{food}を紹介するね！
     EOS
     message = {
@@ -44,7 +48,50 @@ class CreateContent
     messages
   end
 
+  # 個人チャットに送信するメッセージ
+
+  def self.register_me
+    # グループに自分の登録が完了したときのメッセージ
+    register_me = <<~EOS
+    登録が完了しました！
+    EOS
+    message = {
+      type: 'text',
+      text: register_me
+    }
+  end
+
+  def self.already_registered
+    # グループに自分が既に登録されているときのメッセージ
+    already_registered = <<~EOS
+    登録済みです！
+    EOS
+    message = {
+      type: 'text',
+      text: already_registered
+    }
+  end
+
+  def self.recommend_group(group_names)
+    # グループ一覧のメッセージ
+    recommend_group = <<~EOS
+    お久しぶり！
+    グループを選んで、
+    例を参考にメッセージを送ってね！
+    
+    グループ一覧
+    --------------------------------
+    #{group_names.join("\n")}
+    --------------------------------
+    EOS
+    message = {
+      type: 'text',
+      text: recommend_group
+    }
+  end
+
   def self.sample_message
+    # グループ，場所，料理を送信するメッセージのサンプル
     sample_message = <<~EOS
     メッセージ
     [グループ名]
@@ -53,7 +100,7 @@ class CreateContent
     (例)
     メッセージ
     高校サッカー部
-    船橋，焼肉
+    船橋、焼肉
     EOS
     message = {
       type: 'text',
@@ -61,14 +108,47 @@ class CreateContent
     }
   end
 
-  def self.recommend_group(group_names)
-    recommend_group = <<~EOS
-    以下からグループを選んで，メッセージを送ってください
-    #{group_names.join("\n")}
+  def self.group_not_found
+    # 個人とグループが結びついていない時のメッセージ
+    group_not_found = <<~EOS
+    グループが見つかりませんでした．
     EOS
     message = {
       type: 'text',
-      text: recommend_group
+      text: group_not_found
+    }
+  end
+
+  def self.how_to_use
+    # 使い方のメッセージ
+    how_to_use = <<~EOS
+    「What's new」は、
+    久々に会いたいグループに
+    君に代わって飲食店を紹介するよ
+
+    まずは、
+    「久しぶり」
+    とメッセージを送ってね！
+    EOS
+    message = {
+      type: 'text',
+      text: how_to_use
+    }
+  end
+
+  def self.idle_talk
+    # 適当なメッセージ
+    idle_talk = <<~EOS
+    ヤッホーい！
+    最近調子はどう？
+
+    使い方がわからなかったら、
+    「使い方」
+    とメッセージを送ってね！
+    EOS
+    message = {
+      type: 'text',
+      text: idle_talk
     }
   end
 end

--- a/app/models/create_content.rb
+++ b/app/models/create_content.rb
@@ -127,7 +127,7 @@ class CreateContent
     君に代わって飲食店を紹介するよ
 
     まずは、
-    「久しぶり」
+    「お久しぶり」
     とメッセージを送ってね！
     EOS
     message = {

--- a/app/models/create_content.rb
+++ b/app/models/create_content.rb
@@ -48,6 +48,17 @@ class CreateContent
     messages
   end
 
+  def self.register(display_name)
+    # グループにユーザが参加した際に登録したことを知らせるメッセージ
+    register = <<~EOS
+    #{display_name}の登録が完了しました！
+    EOS
+    message = {
+      type: 'text',
+      text: register
+    }
+  end
+
   # 個人チャットに送信するメッセージ
 
   def self.register_me
@@ -105,6 +116,17 @@ class CreateContent
     message = {
       type: 'text',
       text: sample_message
+    }
+  end
+
+  def self.group_mistake
+    # グループ名が間違っている場合のメッセージ
+    group_mistake = <<~EOS
+    グループ名が間違ってるよ．
+    EOS
+    message = {
+      type: 'text',
+      text: group_mistake
     }
   end
 

--- a/app/models/create_content.rb
+++ b/app/models/create_content.rb
@@ -1,46 +1,74 @@
 class CreateContent
-    # 表示数を設定
+  # 表示数を設定
     LIMIT = 3
 
-    def self.greeting_only
-        # 挨拶メッセージ作成
-        greeting = <<~EOS
-        久しぶり〜！今度みんなでご飯でもどう？
-        EOS
-        message = {
-            type: 'text',
-            text: greeting
-        }
-    end
+  def self.greeting_only
+    # 挨拶メッセージ作成
+    greeting = <<~EOS
+    久しぶり〜！今度みんなでご飯でもどう？
+    EOS
+    message = {
+      type: 'text',
+      text: greeting
+    }
+  end
 
-    def self.greeting(place, food)
-        # 挨拶メッセージ作成
-        greeting = <<~EOS
-        久しぶり〜！今度みんなでご飯でもどう？
-        #{place}でお勧めの#{food}を紹介するね！
-        EOS
-        message = {
-            type: 'text',
-            text: greeting
-        }
-    end
+  def self.greeting(place, food)
+    # 挨拶メッセージ作成
+    greeting = <<~EOS
+    久しぶり〜！今度みんなでご飯でもどう？
+    #{place}でお勧めの#{food}を紹介するね！
+    EOS
+    message = {
+      type: 'text',
+      text: greeting
+    }
+  end
 
-    def self.recommend_store(res_data)
-        # お勧め飲食店メッセージ作成
-        messages = []
-        shops = res_data['results']['shop']
-        shops.first(LIMIT).each do |shop|
-            recommend_store = <<~EOS
-            店名： #{shop['name']}
-            最寄駅： #{shop['station_name']}
-            URL： #{shop['urls']['pc']}
-            EOS
-            message = {
-              type: 'text',
-              text: recommend_store
-            }
-            messages.push(message)
-        end
-        messages
+  def self.recommend_store(res_data)
+    # お勧め飲食店メッセージ作成
+    messages = []
+    shops = res_data['results']['shop']
+    shops.first(LIMIT).each do |shop|
+      recommend_store = <<~EOS
+      店名： #{shop['name']}
+      最寄駅： #{shop['station_name']}
+      URL： #{shop['urls']['pc']}
+      EOS
+      message = {
+        type: 'text',
+        text: recommend_store
+      }
+      messages.push(message)
     end
+    messages
+  end
+
+  def self.sample_message
+    sample_message = <<~EOS
+    メッセージ
+    [グループ名]
+    [場所，料理]
+
+    (例)
+    メッセージ
+    高校サッカー部
+    船橋，焼肉
+    EOS
+    message = {
+      type: 'text',
+      text: sample_message
+    }
+  end
+
+  def self.recommend_group(group_names)
+    recommend_group = <<~EOS
+    以下からグループを選んで，メッセージを送ってください
+    #{group_names.join("\n")}
+    EOS
+    message = {
+      type: 'text',
+      text: recommend_group
+    }
+  end
 end

--- a/app/models/food_search_api.rb
+++ b/app/models/food_search_api.rb
@@ -4,18 +4,18 @@ require 'uri'
 
 class FoodSearchAPI
 
-    def self.search(place, food)
-        data = {
-          "key": ENV['API_KEY'], 
-          "address": place,
-          "keyword": food
-        }
-        query = data.to_query
-        uri = URI("http://webservice.recruit.co.jp/hotpepper/gourmet/v1/?" + query)
-        http = Net::HTTP.new(uri.host, uri.port)
-        req = Net::HTTP::Get.new(uri)
-        res = http.request(req)
-        Hash.from_xml(res.body)
-    end
+  def self.search(place, food)
+    data = {
+      "key": ENV['API_KEY'], 
+      "address": place,
+      "keyword": food
+    }
+    query = data.to_query
+    uri = URI("http://webservice.recruit.co.jp/hotpepper/gourmet/v1/?" + query)
+    http = Net::HTTP.new(uri.host, uri.port)
+    req = Net::HTTP::Get.new(uri)
+    res = http.request(req)
+    Hash.from_xml(res.body)
+  end
 
 end

--- a/app/models/food_search_api.rb
+++ b/app/models/food_search_api.rb
@@ -5,6 +5,7 @@ require 'uri'
 class FoodSearchAPI
 
   def self.search(place, food)
+    # 場所と料理から飲食店を検索
     data = {
       "key": ENV['API_KEY'], 
       "address": place,

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,6 @@
+class Group < ApplicationRecord
+  validates :line_group_id, uniqueness: true
+  has_many :group_users
+  has_many :users, through: :group_users
+  accepts_nested_attributes_for :group_users
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/line_api.rb
+++ b/app/models/line_api.rb
@@ -5,6 +5,7 @@ require 'json'
 class LineAPI
 
   def self.bot_join(line_group_id)
+    # LINEグループIDからグループ名を返す
     uri = URI.parse("https://api.line.me/v2/bot/group/#{line_group_id}/summary")
     request = Net::HTTP::Get.new(uri)
     request["Authorization"] = "Bearer #{ENV['LINE_CHANNEL_TOKEN']}"

--- a/app/models/line_api.rb
+++ b/app/models/line_api.rb
@@ -1,0 +1,21 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+class LineAPI
+
+  def self.bot_join(line_group_id)
+    uri = URI.parse("https://api.line.me/v2/bot/group/#{line_group_id}/summary")
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{ENV['LINE_CHANNEL_TOKEN']}"
+    req_options = {
+      use_ssl: uri.scheme == "https",
+    }
+    response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+      http.request(request)
+    end
+    res = JSON.parse(response.body)
+    res['groupName']
+  end
+
+end

--- a/app/models/message_analysis.rb
+++ b/app/models/message_analysis.rb
@@ -3,8 +3,7 @@ class MessageAnalysis
   def self.analysis(text)
     # 個人メッセージからグループ名，場所と料理を返す
     _, group_name, place_food = text.split("\n")
-    place_food = place_food.gsub(" ", ",").gsub("、", ",").gsub("　", ",")
-    place, food = place_food.split(",")
+    place, food = place_food.gsub!(/、|，|\s/, ",").split(",")
     return group_name, place, food
   end
 

--- a/app/models/message_analysis.rb
+++ b/app/models/message_analysis.rb
@@ -1,9 +1,11 @@
 class MessageAnalysis
 
-    def self.analysis(text)
-        # 個人メッセージから場所と料理を返す
-        text = text.gsub(" ", ",").gsub("、", ",").gsub("　", ",")
-        place, food = text.split(",")
-    end
+  def self.analysis(text)
+    # 個人メッセージからグループ名，場所と料理を返す
+    _, group_name, place_food = text.split("\n")
+    place_food = place_food.gsub(" ", ",").gsub("、", ",").gsub("　", ",")
+    place, food = place_food.split(",")
+    return group_name, place, food
+  end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  validates :line_user_id, uniqueness: true
+  has_many :group_users
+  has_many :groups, through: :group_users
+end

--- a/db/migrate/20211125020846_create_users.rb
+++ b/db/migrate/20211125020846_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :line_user_id, null: false
+      t.string :display_name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211125021633_create_groups.rb
+++ b/db/migrate/20211125021633_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :groups do |t|
+      t.string :line_group_id, null: false
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211125022041_create_group_users.rb
+++ b/db/migrate/20211125022041_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :group_users do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }
+      t.references :group, null: false, foreign_key: { on_delete: :cascade }
+      t.timestamps
+    end
+    add_index :group_users, [:group_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_112934) do
+ActiveRecord::Schema.define(version: 2021_11_25_022041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "group_users", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id", "user_id"], name: "index_group_users_on_group_id_and_user_id", unique: true
+    t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id"], name: "index_group_users_on_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "line_group_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "line_user_id", null: false
+    t.string "display_name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "widgets", force: :cascade do |t|
     t.string "name"
@@ -23,4 +47,6 @@ ActiveRecord::Schema.define(version: 2020_02_13_112934) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "group_users", "groups", on_delete: :cascade
+  add_foreign_key "group_users", "users", on_delete: :cascade
 end


### PR DESCRIPTION
## 実装の背景・目的

個人チャットからグループ，場所，料理を選択し，選択されたグループチャットにお勧めの飲食店を送信．

## やったこと

- Botがグループに入ったらグループIDとグループ名をグループデータベースに追加
- ユーザがBotのいるグループに入ったら，ユーザID，ユーザ表示名，今いるグループをユーザデータベースに追加
- callbackの中身を変更．特定のワードに反応するようにしました！

## キャプチャ

![個人チャットでグループ名，場所，料理を送信](https://user-images.githubusercontent.com/82089820/143424528-2e722734-60ce-40d1-9197-0acfe713a101.png)

![グルメAPIの結果が送信される](https://user-images.githubusercontent.com/82089820/143424567-519d1858-f578-41af-8950-c7037d199d2e.png)

![グルメAPIの結果が送信される](https://user-images.githubusercontent.com/82089820/143424577-43ca6606-9b76-4797-a3bd-d95f41d51e09.png)

## 補足

- リッチメニューを使ってみる！
- 特定ワード以外の送信内容を考える！
- どの機能から実装するか考える！
